### PR TITLE
Remove startAngle increment statement from comment block

### DIFF
--- a/chapters/03_oscillation.html
+++ b/chapters/03_oscillation.html
@@ -914,8 +914,9 @@ void setup() {
 void draw() {
   background(255);
 
-  //[full] In order to move the wave, we start at a different theta value each frame.  startAngle += 0.02;
-float angle = startAngle;
+  //[full] In order to move the wave, we start at a different theta value each frame.
+  float angle = startAngle;
+  startAngle += 0.02;
   //[end]
 
   for (int x = 0; x &lt;= width; x += 24) {


### PR DESCRIPTION
Chapter 3. Example 3.9. This patch fixes a typo which resulted in code, which is necessary for the example to work as expected, appearing inside the comment block.