### PR TITLE
Fixes broken link to Exploring Emergence site

### DIFF
--- a/chapters/07_ca.html
+++ b/chapters/07_ca.html
@@ -695,7 +695,7 @@ class CA {
 
 <ul>
 	<li>
-	<p><a href="http://llk.media.mit.edu/projects/emergence/">Exploring Emergence</a> by Mitchel Resnick and Brian Silverman, Lifelong Kindergarten Group, MIT Media Laboratory</p>
+	<p><a href="http://www.playfulinvention.com/emergence/">Exploring Emergence</a> by Mitchel Resnick and Brian Silverman, Lifelong Kindergarten Group, MIT Media Laboratory</p>
 	</li>
 	<li>
 	<p><a href="https://sklise.github.io/conways-game-of-life/">Conway’s Game of Life</a> by Steven Klise</p>


### PR DESCRIPTION
Fixes broken link for "Exploring Emergence" by Mitchel Resnick and Brian Silverman, Lifelong Kindergarten Group, MIT Media Laboratory.

URL was `http://llk.media.mit.edu/projects/emergence/`, this PR updates it to [http://www.playfulinvention.com/emergence/](http://www.playfulinvention.com/emergence/)