### PR TITLE
Reference Figure 1.10 explicitly

### DIFF
--- a/chapters/01_vectors.html
+++ b/chapters/01_vectors.html
@@ -692,7 +692,7 @@ The distributive rule with 2 vectors, 1 scalar: <span data-type="equation">(\vec
 
 <a data-primary="Pythagoras" data-type="indexterm"></a> <a data-primary="Pythagorean theorem" data-type="indexterm"></a>
 
-<p>Notice in the above diagram how the vector, drawn as an arrow and two components (<code>x</code> and <code>y</code>), creates a right triangle. The sides are the components and the hypotenuse is the arrow itself. We’re very lucky to have this right triangle, because once upon a time, a Greek mathematician named Pythagoras discovered a lovely formula to describe the relationship between the sides and hypotenuse of a right triangle.</p>
+<p>Notice in Figure 1.10 how the vector, drawn as an arrow and two components (<code>x</code> and <code>y</code>), creates a right triangle. The sides are the components and the hypotenuse is the arrow itself. We’re very lucky to have this right triangle, because once upon a time, a Greek mathematician named Pythagoras discovered a lovely formula to describe the relationship between the sides and hypotenuse of a right triangle.</p>
 
 <figure class="half-width-right" id="chapter01_figure11"><img alt="Figure 1.11: The Pythagorean Theorem" src="chapter01/ch01_11.png" />
 <figcaption>Figure 1.11: The Pythagorean Theorem&nbsp;</figcaption>


### PR DESCRIPTION
At least when viewing the web version, the diagram is actually on the right of the text but it seems better to refer to it by name rather than spatially.