### PR TITLE
Convert uses of PVector.magnitude() to PVector.mag()

### DIFF
--- a/chapters/02_forces.html
+++ b/chapters/02_forces.html
@@ -769,7 +769,7 @@ void draw() {
 	<p><span data-type="equation">\rho</span> is the Greek letter <em>rho</em>, and refers to the density of the liquid, something we don’t need to worry about. We can simplify the problem and consider this to have a constant value of 1.</p>
 	</li>
 	<li>
-	<p><span data-type="equation">v</span> refers to the speed of the object moving. OK, we’ve got this one! The object’s speed is the magnitude of the velocity vector: <code>velocity.magnitude()</code>. And <span data-type="equation">v^2</span> just means <span data-type="equation">v</span> squared or <span data-type="equation">v \times v</span>.</p>
+	<p><span data-type="equation">v</span> refers to the speed of the object moving. OK, we’ve got this one! The object’s speed is the magnitude of the velocity vector: <code>velocity.mag()</code>. And <span data-type="equation">v^2</span> just means <span data-type="equation">v</span> squared or <span data-type="equation">v \times v</span>.</p>
 	</li>
 	<li>
 	<p><span data-type="equation">A</span> refers to the frontal area of the object that is pushing through the liquid (or gas). An aerodynamic Lamborghini, for example, will experience less air resistance than a boxy Volvo. Nevertheless, for a basic simulation, we can consider our object to be spherical and ignore this element.</p>

--- a/chapters/05_physicslib.html
+++ b/chapters/05_physicslib.html
@@ -2331,7 +2331,7 @@ a.normalize();
 			<td>
 			<pre>
 Vec2D a = new Vec2D(1,-1);
-float m = a.magnitude();
+float m = a.mag();
 a.normalize();
 </pre>
 			</td>

--- a/noc_html/processingjs/chapter04/flight404/flight404_particles_2_GLtexture/particle.pde
+++ b/noc_html/processingjs/chapter04/flight404/flight404_particles_2_GLtexture/particle.pde
@@ -78,7 +78,7 @@ class Particle{
     // if the particle is moving fast enough, when it hits the ground it can
     // split into a bunch of smaller particles.
     if( ISBOUNCING ){
-      bounceVel = vel.magnitude();
+      bounceVel = vel.mag();
       
       vel.scaleSelf( .7 );
       vel.y *= -( ( radius/40.0 ) * .5 );

--- a/noc_html/processingjs/chapter04/flight404/flight404_particles_2_simple/particle.pde
+++ b/noc_html/processingjs/chapter04/flight404/flight404_particles_2_simple/particle.pde
@@ -78,7 +78,7 @@ class Particle{
     // if the particle is moving fast enough, when it hits the ground it can
     // split into a bunch of smaller particles.
     if( ISBOUNCING ){
-      bounceVel = vel.magnitude();
+      bounceVel = vel.mag();
       
       vel.scaleSelf( .7 );
       vel.y *= -( ( radius/40.0 ) * .5 );


### PR DESCRIPTION
Both Processing and Processing.js seem to have switched to using PVector.mag() for getting the magnitude of a vector.