### PR TITLE
Use https: where applicable

### DIFF
--- a/noc_html/views/document.html.erb
+++ b/noc_html/views/document.html.erb
@@ -2,8 +2,8 @@
 <head>
 	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
 	<title>The Nature of Code</title>
-	<script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
-	<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
+	<script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+	<script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.7.1/jquery.min.js"></script>
 	<script type="text/javascript" src="/book/javascripts/codeprocessing.js"></script>
 	<script type="text/javascript" src="/book/processingjs/processing.js"></script>
   <script type="text/javascript" src="/book/processingjs/lazyloading.js"></script>
@@ -110,16 +110,16 @@
 			<div class="one-third" id="licenses">
         <h4>Licenses</h4>
         <p>
-          <a class="license-badge" rel="license" href="http://creativecommons.org/licenses/by-nc/3.0/"><img alt="Creative Commons License" style="border-width:0" src="http://i.creativecommons.org/l/by-nc/3.0/88x31.png" /></a>
-          <a class="license-badge" rel="license" href="http://creativecommons.org/licenses/LGPL/2.1/"><img alt="LGPL License" style="border-width:0" src="http://www.gnu.org/graphics/lgplv3-88x31.png" /></a>
+          <a class="license-badge" rel="license" href="https://creativecommons.org/licenses/by-nc/3.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-nc/3.0/88x31.png" /></a>
+          <a class="license-badge" rel="license" href="https://creativecommons.org/licenses/LGPL/2.1/"><img alt="LGPL License" style="border-width:0" src="https://www.gnu.org/graphics/lgplv3-88x31.png" /></a>
         </p>
 
         <p>
-          The book's text and illustrations are licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-nc/3.0/">Creative Commons Attribution-NonCommercial 3.0 Unported License</a>.
+          The book's text and illustrations are licensed under a <a rel="license" href="https://creativecommons.org/licenses/by-nc/3.0/">Creative Commons Attribution-NonCommercial 3.0 Unported License</a>.
         </p>
 
         <p>
-          All of the book's source code is licensed under the <a rel="license" href="http://creativecommons.org/licenses/LGPL/2.1/">GNU Lesser General Public License</a> as published by the Free Software Foundation; either version 2.1 of the License, or (at your option) any later version.
+          All of the book's source code is licensed under the <a rel="license" href="https://creativecommons.org/licenses/LGPL/2.1/">GNU Lesser General Public License</a> as published by the Free Software Foundation; either version 2.1 of the License, or (at your option) any later version.
         </p>
 
       </div>
@@ -129,7 +129,7 @@
 
         <p>This book was generated with <a href="http://magicbookproject.com">The Magic Book Project</a>.
 
-        <p>This book would not have been possible without the generous support of <a href="http://www.kickstarter.com/projects/shiffman/the-nature-of-code-book-project">Kickstarter</a> backers.</p> 
+        <p>This book would not have been possible without the generous support of <a href="https://www.kickstarter.com/projects/shiffman/the-nature-of-code-book-project">Kickstarter</a> backers.</p> 
 
         <p>This book is typeset on the web in Georgia with headers in Proxima Nova.</p>
 
@@ -138,11 +138,11 @@
 
       <div class="one-third">
         <h4>Author</h4>
-        <p>Daniel Shiffman is a professor of the <a href="http://itp.nyu.edu/">Interactive Telecommunications Program</a> at New York University.</p>
+        <p>Daniel Shiffman is a professor of the <a href="https://itp.nyu.edu/">Interactive Telecommunications Program</a> at New York University.</p>
 
         <p>He is the author of <a href="http://www.learningprocessing.com/">Learning Processing</a>.</p>
 
-        <p><a href="https://twitter.com/shiffman">Twitter</a> <a href="http://github.com/shiffman">GitHub</a></p>
+        <p><a href="https://twitter.com/shiffman">Twitter</a> <a href="https://github.com/shiffman">GitHub</a></p>
       </div>
 		</div>
 	</div>


### PR DESCRIPTION
The remaining http: links don't have valid certificates so they're left as-is.

This change makes it possible to use the page through an https domain, e.g. the ipfs.io gateway.